### PR TITLE
fix: update bundle browser script

### DIFF
--- a/bundle_wasm_for_web.js
+++ b/bundle_wasm_for_web.js
@@ -18,15 +18,11 @@ if (typeof window === "object") {
 
 const originalSourceCode = fs.readFileSync(fileToPatch, 'utf-8');
 const modifiedSourceCode = originalSourceCode
-  .replace(`var wasmBinaryFile="re2Lib.wasm";`, codeToPaste)
+  .replace(`var wasmBinaryFile;wasmBinaryFile="re2Lib.wasm";`, codeToPaste)
   .replace('process["on"]("unhandledRejection",abort);', '')
   .replace(
     'var out=Module["print"]||console.log.bind(console);var err=Module["printErr"]||console.warn.bind(console);',
     'var out=function out(){};var err=function err(){};'
-  )
-  .replace(
-    'if(!wasmBinary&&typeof WebAssembly.instantiateStreaming==="function"&&!isDataURI(wasmBinaryFile)&&!isFileURI(wasmBinaryFile)&&typeof fetch==="function")',
-    'if(!wasmBinary&&!isDataURI(wasmBinaryFile)&&!isFileURI(wasmBinaryFile))'
   );
 
 fs.writeFileSync(fileToPatch, modifiedSourceCode, 'utf-8');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dashevo/wasm-re2",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dashevo/wasm-re2",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "ISC",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.1.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@dashevo/wasm-re2",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "RE2 for different platforms (Linux, Windows, macOS)",
   "main": "./lib/scripts/re2.js",
   "types": "./lib/scripts/re2.d.ts",
   "engines": {
-    "node": ">=18"
+    "node": ">=16"
   },
   "jest": {
     "testRegex": ".test\\.js",


### PR DESCRIPTION
Update browser bundle replace code as it is updated after our recent emscripten SDK update. Also decreased minimum node.js SDK version to 16, because emscripten is so.