### PR TITLE
Update repo link in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Leffffff/re2.git"
+    "url": "https://github.com/dashpay/wasm-re2.git"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
So the [npm package page](https://www.npmjs.com/package/@dashevo/wasm-re2) links to the correct repository.